### PR TITLE
Add keyboard support with better word failure notices

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,7 +16,7 @@ export const Button: FunctionalComponent<ButtonProps> = ({
 }) => (
   <button
     {...props}
-    class={`${theme} ${hover} bwa-0 ${radius} pwa-4 fld-row flg-3 ai-ctr crsr-pointer z-1 ${className} ${props.class}`}
+    class={`${theme} ${hover} bwa-0 ${radius} pwa-4 fld-row flg-3 ai-ctr ${props.disabled ? 'crsr-default' : 'crsr-pointer'} z-1 ${className} ${props.class}`}
   >
     {children}
   </button>

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -60,6 +60,9 @@ export const Game: FunctionalComponent<GameProps> = ({
       else if (key === "enter" && word.length > 0) {
         handleSubmit();
       }
+      else if (key === "escape") {
+        handleClear();
+      }
       else if (key.length === 1 && key >= "a" && key <= "z") {
         handleLetterClick(key);
       }

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -1,5 +1,5 @@
 import { h, FunctionalComponent } from "preact";
-import { useState, useCallback } from "preact/hooks";
+import { useState, useCallback, useEffect } from "preact/hooks";
 import { MdRefresh, MdArrowBack, MdClear, MdCheck } from "react-icons/md";
 
 import { Game as GameModel } from "../../stores/game";
@@ -51,11 +51,32 @@ export const Game: FunctionalComponent<GameProps> = ({
     onSubmit(word);
     setWord("");
   }, [word, setWord, onSubmit]);
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if (key === "backspace") {
+        handleDelete();
+      }
+      else if (key === "enter" && word.length > 0) {
+        handleSubmit();
+      }
+      else if (key.length === 1 && key >= "a" && key <= "z") {
+        handleLetterClick(key);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    }
+  });
+
 
   return (
     <div class="fld-col flg-4 ai-ctr vwc-p100">
       <div class="vh-2 fs-u5 ta-c fld-row ai-ctr jc-ctr ct-lighter ff-head ps-rel">
-        <Highlight word={word} middle={game.middle} />
+        <Highlight chars={chars} word={word} middle={game.middle} />
       </div>
 
       <div class="fld-col ai-ctr vwc-p100">

--- a/src/components/Game/Highlight.tsx
+++ b/src/components/Game/Highlight.tsx
@@ -12,7 +12,7 @@ const highlight = (chars: string[], middle: string) => (char: string) => {
   if (middle.toLowerCase() === input) {
     return <span class="cf-rev-honey-dark bounceIn">{char}</span>;
   }
-  if (chars.indexOf(input) === -1) {
+  if (!chars.includes(input)) {
     return <span class="cf-disabled bounceIn">{char}</span>;
   }
   return <span class="bounceIn">{char}</span>;

--- a/src/components/Game/Highlight.tsx
+++ b/src/components/Game/Highlight.tsx
@@ -1,26 +1,32 @@
 import { h, FunctionalComponent } from "preact";
 
 interface HighlightProps {
+  chars: string[],
   word: string;
   middle: string;
   className?: string;
 }
 
-const highlight = (middle: string) => (char: string) => {
-  if (middle.toLowerCase() === char.toLowerCase()) {
+const highlight = (chars: string[], middle: string) => (char: string) => {
+  const input = char.toLowerCase();
+  if (middle.toLowerCase() === input) {
     return <span class="cf-rev-honey-dark bounceIn">{char}</span>;
+  }
+  if (chars.indexOf(input) === -1) {
+    return <span class="cf-disabled bounceIn">{char}</span>;
   }
   return <span class="bounceIn">{char}</span>;
 };
 
 export const Highlight: FunctionalComponent<HighlightProps> = ({
+  chars,
   word,
   middle,
   className = "",
 }) => {
   return (
     <span class={className}>
-      {word.toUpperCase().split("").map(highlight(middle))}
+      {word.toUpperCase().split("").map(highlight(chars, middle))}
     </span>
   );
 };

--- a/src/stores/game/store.ts
+++ b/src/stores/game/store.ts
@@ -76,9 +76,18 @@ const submitWordRunEvery = filterEvery(
     if (!DE.isSuccess(game)) {
       settingsStore.dispatch(failureBuzz);
       notificationsStore.dispatch(failureNotice("No game!"));
+    } else if (guess.length < 4) {
+      settingsStore.dispatch(failureBuzz);
+      notificationsStore.dispatch(failureNotice(guess, "Too Short"));
+    } else if (!guess.split("").every((c) => c === game.value.right.middle || game.value.right.chars.includes(c))) {
+      settingsStore.dispatch(failureBuzz);
+      notificationsStore.dispatch(failureNotice(guess, "Bad Letters"));
+    } else if (guess.indexOf(game.value.right.middle) === -1) {
+      settingsStore.dispatch(failureBuzz);
+      notificationsStore.dispatch(failureNotice(guess, "Missing Center Letter"));
     } else if (!game.value.right.dictionary.some(eqInsensitive(guess))) {
       settingsStore.dispatch(failureBuzz);
-      notificationsStore.dispatch(failureNotice(guess, "Incorrect"));
+      notificationsStore.dispatch(failureNotice(guess, "Not In Word List"));
     } else if (save.found.some(eqInsensitive(guess))) {
       settingsStore.dispatch(failureBuzz);
       notificationsStore.dispatch(infoNotice(guess, "Already Found"));

--- a/src/stores/game/store.ts
+++ b/src/stores/game/store.ts
@@ -82,7 +82,7 @@ const submitWordRunEvery = filterEvery(
     } else if (!guess.split("").every((c) => c === game.value.right.middle || game.value.right.chars.includes(c))) {
       settingsStore.dispatch(failureBuzz);
       notificationsStore.dispatch(failureNotice(guess, "Bad Letters"));
-    } else if (guess.indexOf(game.value.right.middle) === -1) {
+    } else if (!guess.includes(game.value.right.middle)) {
       settingsStore.dispatch(failureBuzz);
       notificationsStore.dispatch(failureNotice(guess, "Missing Center Letter"));
     } else if (!game.value.right.dictionary.some(eqInsensitive(guess))) {


### PR DESCRIPTION
Adds ability to use keyboard to input letters, backspace to delete letters, and enter to submit words.

Because the "enter" key now allows the submission of words without any validation (i.e. the word length does not need to be at least 4 in order to press "enter"), we need more error messages to precisely describe why a word is not accepted. This more accurately mimics the behavior of the original game, but differs from how this clone is implemented.

Preview:
![image](https://user-images.githubusercontent.com/6465531/163664515-c03a9423-8c70-423a-881f-24b421562f5c.png)

Also quick fix to make `cursor: default` on disabled buttons.