### PR TITLE
Prevent text highlighting when double-clicking in game

### DIFF
--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -58,7 +58,10 @@ export const Game: FunctionalComponent<GameProps> = ({
         <Highlight word={word} middle={game.middle} />
       </div>
 
-      <div class="fld-col ai-ctr vwc-p100">
+      <div 
+        class="fld-col ai-ctr vwc-p100"
+        style={{userSelect: 'none'}}
+      >
         <div class="fld-row flg-4 jc-spb">
           <Button
             className="pwx-5 pwy-5 fs-u5"


### PR DESCRIPTION
Double-clicking letters, which can happen when trying to enter the same letter twice in succession, can highlight text below the game, which could have unintended consequences.

![image](https://user-images.githubusercontent.com/6465531/163666686-d242f9a5-511e-437d-9c01-87ef52076191.png)

Setting `user-select` to `none` solves this issue. I see this project uses a CSS library, but I could not find any related to `user-select`. This PR was just made as a proof-of-concept that this fix can be made. Feel free to close this PR to use the custom CSS library.